### PR TITLE
Add Mailchimp response checks

### DIFF
--- a/popmagique.php
+++ b/popmagique.php
@@ -340,7 +340,22 @@ class PopMagique {
             'body' => json_encode($data)
         );
         
-        wp_remote_post($url, $args);
+        $response = wp_remote_post($url, $args);
+
+        if (is_wp_error($response)) {
+            $message = 'Mailchimp API error: ' . $response->get_error_message();
+            error_log($message);
+            wp_mail(get_option('admin_email'), 'PopMagique Mailchimp Error', $message);
+            return;
+        }
+
+        $code = wp_remote_retrieve_response_code($response);
+        if ($code < 200 || $code >= 300) {
+            $body    = wp_remote_retrieve_body($response);
+            $message = sprintf('Mailchimp API request failed with status %s: %s', $code, $body);
+            error_log($message);
+            wp_mail(get_option('admin_email'), 'PopMagique Mailchimp Error', $message);
+        }
     }
     
     /**


### PR DESCRIPTION
## Summary
- verify Mailchimp API response after `wp_remote_post`
- log and email admin when a request fails

## Testing
- `php -l popmagique.php` *(fails: php not installed)*

------
https://chatgpt.com/codex/tasks/task_e_685bc91e1d88832bbc967fa70cee174a