### PR TITLE
Remove unused newsletter features

### DIFF
--- a/assets/frontend.js
+++ b/assets/frontend.js
@@ -25,29 +25,4 @@ jQuery(function($) {
         $(this).closest('.popmagique-popup').fadeOut();
     });
 
-    $('#popmagique-subscribe-form').on('submit', function(e) {
-        e.preventDefault();
-        var form = $(this);
-        var button = form.find('button');
-        var loading = form.find('.button-loading');
-        var text = form.find('.button-text');
-
-        loading.show();
-        text.hide();
-
-        $.post(popmagique_config.ajax_url, {
-            action: 'popmagique_subscribe_email',
-            nonce: popmagique_config.nonce,
-            email: form.find('input[name="email"]').val()
-        }, function(res) {
-            loading.hide();
-            text.show();
-            if (res.success) {
-                $('#popmagique-newsletter-form').hide();
-                $('#popmagique-success-message').show();
-            } else {
-                alert(res.data || 'Erreur');
-            }
-        });
-    });
 });

--- a/popmagique.php
+++ b/popmagique.php
@@ -56,17 +56,11 @@ class PopMagique {
         'exit_popup' => array(
             'enabled' => true,
             'title' => '✋ Attendez !',
-            'content' => 'Ne partez pas sans vous abonner à notre newsletter pour recevoir nos meilleures offres et conseils exclusifs.',
-            'button_text' => 'S\'abonner maintenant',
-            'button_color' => '#3B82F6',
+            'content' => 'Ne partez pas sans profiter de nos meilleures offres.',
             'background_color' => 'rgba(255, 255, 255, 0.1)',
             'text_color' => '#1F2937',
             'font_size' => '16px',
-            'font_family' => 'Inter, sans-serif',
-            'email_placeholder' => 'Votre adresse email...',
-            'success_message' => '🎉 Merci ! Vous êtes maintenant abonné(e) à notre newsletter.',
-            'mailchimp_api_key' => '',
-            'mailchimp_list_id' => ''
+            'font_family' => 'Inter, sans-serif'
         )
     );
     
@@ -313,11 +307,6 @@ class PopMagique {
             wp_send_json_error('Erreur lors de l\'inscription');
         }
         
-        // Intégration Mailchimp si configurée
-        $options = get_option('popmagique_options', $this->default_options);
-        if (!empty($options['exit_popup']['mailchimp_api_key']) && !empty($options['exit_popup']['mailchimp_list_id'])) {
-            $this->add_to_mailchimp($email, $options['exit_popup']);
-        }
 
         wp_send_json_success('Inscription réussie !');
     }
@@ -350,47 +339,7 @@ class PopMagique {
         wp_send_json_success('Abonné supprimé');
     }
     
-    /**
-     * Ajouter un email à Mailchimp
-     */
-    private function add_to_mailchimp($email, $settings) {
-        $api_key = $settings['mailchimp_api_key'];
-        $list_id = $settings['mailchimp_list_id'];
-        
-        $datacenter = substr($api_key, strpos($api_key, '-') + 1);
-        $url = "https://{$datacenter}.api.mailchimp.com/3.0/lists/{$list_id}/members";
-        
-        $data = array(
-            'email_address' => $email,
-            'status' => 'subscribed'
-        );
-        
-        $args = array(
-            'method' => 'POST',
-            'headers' => array(
-                'Authorization' => 'Basic ' . base64_encode('user:' . $api_key),
-                'Content-Type' => 'application/json'
-            ),
-            'body' => json_encode($data)
-        );
-        
-        $response = wp_remote_post($url, $args);
 
-        if (is_wp_error($response)) {
-            $message = 'Mailchimp API error: ' . $response->get_error_message();
-            error_log($message);
-            wp_mail(get_option('admin_email'), 'PopMagique Mailchimp Error', $message);
-            return;
-        }
-
-        $code = wp_remote_retrieve_response_code($response);
-        if ($code < 200 || $code >= 300) {
-            $body    = wp_remote_retrieve_body($response);
-            $message = sprintf('Mailchimp API request failed with status %s: %s', $code, $body);
-            error_log($message);
-            wp_mail(get_option('admin_email'), 'PopMagique Mailchimp Error', $message);
-        }
-    }
     
     /**
      * Nettoyer les paramètres
@@ -419,16 +368,10 @@ class PopMagique {
             'enabled' => isset($settings['exit_popup']['enabled']) ? (bool)$settings['exit_popup']['enabled'] : false,
             'title' => sanitize_text_field($settings['exit_popup']['title']),
             'content' => sanitize_textarea_field($settings['exit_popup']['content']),
-            'button_text' => sanitize_text_field($settings['exit_popup']['button_text']),
-            'button_color' => sanitize_hex_color($settings['exit_popup']['button_color']),
             'background_color' => sanitize_text_field($settings['exit_popup']['background_color']),
             'text_color' => sanitize_hex_color($settings['exit_popup']['text_color']),
             'font_size' => sanitize_text_field($settings['exit_popup']['font_size']),
-            'font_family' => sanitize_text_field($settings['exit_popup']['font_family']),
-            'email_placeholder' => sanitize_text_field($settings['exit_popup']['email_placeholder']),
-            'success_message' => sanitize_text_field($settings['exit_popup']['success_message']),
-            'mailchimp_api_key' => sanitize_text_field($settings['exit_popup']['mailchimp_api_key']),
-            'mailchimp_list_id' => sanitize_text_field($settings['exit_popup']['mailchimp_list_id'])
+            'font_family' => sanitize_text_field($settings['exit_popup']['font_family'])
         );
         
         return $clean;

--- a/templates/admin-page.php
+++ b/templates/admin-page.php
@@ -26,7 +26,6 @@ if (!defined('ABSPATH')) {
         <nav class="nav-tab-wrapper">
             <a href="#entry-popup" class="nav-tab nav-tab-active">🎯 Popup d'Entrée</a>
             <a href="#exit-popup" class="nav-tab">✋ Popup de Sortie</a>
-            <a href="#advanced" class="nav-tab">⚙️ Avancé</a>
         </nav>
 
         <!-- Popup d'Entrée -->
@@ -167,55 +166,10 @@ if (!defined('ABSPATH')) {
                                 <textarea name="exit_popup[content]" rows="4" class="large-text"><?php echo esc_textarea($options['exit_popup']['content']); ?></textarea>
                             </td>
                         </tr>
-                        <tr>
-                            <th scope="row">Placeholder email</th>
-                            <td>
-                                <input type="text" name="exit_popup[email_placeholder]" value="<?php echo esc_attr($options['exit_popup']['email_placeholder']); ?>" class="regular-text">
-                            </td>
-                        </tr>
-                        <tr>
-                            <th scope="row">Texte du bouton</th>
-                            <td>
-                                <input type="text" name="exit_popup[button_text]" value="<?php echo esc_attr($options['exit_popup']['button_text']); ?>" class="regular-text">
-                            </td>
-                        </tr>
-                        <tr>
-                            <th scope="row">Couleur du bouton</th>
-                            <td>
-                                <input type="color" name="exit_popup[button_color]" value="<?php echo esc_attr($options['exit_popup']['button_color']); ?>">
-                            </td>
-                        </tr>
-                        <tr>
-                            <th scope="row">Message de succès</th>
-                            <td>
-                                <input type="text" name="exit_popup[success_message]" value="<?php echo esc_attr($options['exit_popup']['success_message']); ?>" class="regular-text">
-                            </td>
-                        </tr>
                     </table>
                 </div>
             </div>
 
-            <div class="postbox">
-                <h2 class="hndle">Intégration Mailchimp</h2>
-                <div class="inside">
-                    <table class="form-table">
-                        <tr>
-                            <th scope="row">Clé API Mailchimp</th>
-                            <td>
-                                <input type="text" name="exit_popup[mailchimp_api_key]" value="<?php echo esc_attr($options['exit_popup']['mailchimp_api_key']); ?>" class="regular-text">
-                                <p class="description">Optionnel : Clé API pour synchroniser avec Mailchimp</p>
-                            </td>
-                        </tr>
-                        <tr>
-                            <th scope="row">ID de liste Mailchimp</th>
-                            <td>
-                                <input type="text" name="exit_popup[mailchimp_list_id]" value="<?php echo esc_attr($options['exit_popup']['mailchimp_list_id']); ?>" class="regular-text">
-                                <p class="description">ID de la liste Mailchimp où ajouter les abonnés</p>
-                            </td>
-                        </tr>
-                    </table>
-                </div>
-            </div>
 
             <div class="postbox">
                 <h2 class="hndle">Style et Apparence</h2>
@@ -261,45 +215,6 @@ if (!defined('ABSPATH')) {
             </div>
         </div>
 
-        <!-- Avancé -->
-        <div id="advanced" class="tab-content">
-            <div class="postbox">
-                <h2 class="hndle">Paramètres Avancés</h2>
-                <div class="inside">
-                    <h3>🎨 Aperçu des Popups</h3>
-                    <p>Testez vos popups avant de les publier :</p>
-                    <div class="preview-buttons">
-                        <button type="button" class="button button-secondary" id="preview-entry">👁️ Aperçu Popup d'Entrée</button>
-                        <button type="button" class="button button-secondary" id="preview-exit">👁️ Aperçu Popup de Sortie</button>
-                    </div>
-                    
-                    <hr>
-                    
-                    <h3>📊 Statistiques</h3>
-                    <div class="stats-grid">
-                        <div class="stat-box">
-                            <div class="stat-number"><?php echo wp_count_posts()->publish; ?></div>
-                            <div class="stat-label">Articles publiés</div>
-                        </div>
-                        <div class="stat-box">
-                            <div class="stat-number"><?php 
-                                global $wpdb;
-                                $table_name = $wpdb->prefix . 'popmagique_subscribers';
-                                echo $wpdb->get_var("SELECT COUNT(*) FROM $table_name");
-                            ?></div>
-                            <div class="stat-label">Abonnés newsletter</div>
-                        </div>
-                    </div>
-                    
-                    <hr>
-                    
-                    <h3>🔧 Outils</h3>
-                    <p>
-                        <em>Fonctionnalités d'import/export à venir.</em>
-                    </p>
-                </div>
-            </div>
-        </div>
     </div>
 
     <div class="popmagique-footer">

--- a/templates/popups.php
+++ b/templates/popups.php
@@ -70,57 +70,13 @@ if (!defined('ABSPATH')) {
             </button>
             
             <div class="popmagique-content">
-                <div id="popmagique-newsletter-form">
-                    <h2 class="popmagique-title">
-                        <?php echo esc_html($options['exit_popup']['title']); ?>
-                    </h2>
-                    
-                    <p class="popmagique-text">
-                        <?php echo esc_html($options['exit_popup']['content']); ?>
-                    </p>
-                    
-                    <form id="popmagique-subscribe-form" class="popmagique-form">
-                        <div class="popmagique-form-group">
-                            <div class="popmagique-input-wrapper">
-                                <svg class="popmagique-input-icon" width="20" height="20" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2">
-                                    <path d="M4 4h16c1.1 0 2 .9 2 2v12c0 1.1-.9 2-2 2H4c-1.1 0-2-.9-2-2V6c0-1.1.9-2 2-2z"></path>
-                                    <polyline points="22,6 12,13 2,6"></polyline>
-                                </svg>
-                                <input type="email" 
-                                       name="email" 
-                                       placeholder="<?php echo esc_attr($options['exit_popup']['email_placeholder']); ?>" 
-                                       required 
-                                       class="popmagique-input">
-                            </div>
-                        </div>
-                        
-                        <div class="popmagique-actions">
-                            <button type="submit" 
-                                    class="popmagique-button popmagique-button-primary"
-                                    style="background-color: <?php echo esc_attr($options['exit_popup']['button_color']); ?>;">
-                                <span class="button-text"><?php echo esc_html($options['exit_popup']['button_text']); ?></span>
-                                <span class="button-loading" style="display: none;">
-                                    <svg class="spinner" width="20" height="20" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2">
-                                        <path d="M21 12a9 9 0 11-6.219-8.56"/>
-                                    </svg>
-                                    Inscription...
-                                </span>
-                            </button>
-                        </div>
-                    </form>
-                </div>
-                
-                <div id="popmagique-success-message" style="display: none;">
-                    <div class="popmagique-success-icon">
-                        <svg width="48" height="48" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2">
-                            <path d="M22 11.08V12a10 10 0 1 1-5.93-9.14"></path>
-                            <polyline points="22,4 12,14.01 9,11.01"></polyline>
-                        </svg>
-                    </div>
-                    <h2 class="popmagique-title">
-                        <?php echo esc_html($options['exit_popup']['success_message']); ?>
-                    </h2>
-                </div>
+                <h2 class="popmagique-title">
+                    <?php echo esc_html($options['exit_popup']['title']); ?>
+                </h2>
+
+                <p class="popmagique-text">
+                    <?php echo esc_html($options['exit_popup']['content']); ?>
+                </p>
             </div>
         </div>
     </div>


### PR DESCRIPTION
## Summary
- clean up default exit popup configuration
- drop Mailchimp integration
- remove newsletter form markup and JS
- simplify admin UI and remove "Avancé" tab

## Testing
- `php -l popmagique.php` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_685bfcf069d8832b9bffc97382905908