### PR TITLE
Add typography options

### DIFF
--- a/popmagique.php
+++ b/popmagique.php
@@ -51,6 +51,9 @@ class PopMagique {
             'text_color' => '#1F2937',
             'font_size' => '16px',
             'font_family' => 'Inter, sans-serif',
+            'font_weight' => 'normal',
+            'font_style' => 'normal',
+            'text_transform' => 'none',
             'image_url' => ''
         ),
         'exit_popup' => array(
@@ -60,7 +63,10 @@ class PopMagique {
             'background_color' => 'rgba(255, 255, 255, 0.1)',
             'text_color' => '#1F2937',
             'font_size' => '16px',
-            'font_family' => 'Inter, sans-serif'
+            'font_family' => 'Inter, sans-serif',
+            'font_weight' => 'normal',
+            'font_style' => 'normal',
+            'text_transform' => 'none'
         )
     );
     
@@ -352,7 +358,7 @@ class PopMagique {
             'enabled' => isset($settings['entry_popup']['enabled']) ? (bool)$settings['entry_popup']['enabled'] : false,
             'delay' => absint($settings['entry_popup']['delay']),
             'title' => sanitize_text_field($settings['entry_popup']['title']),
-            'content' => sanitize_textarea_field($settings['entry_popup']['content']),
+            'content' => wp_kses_post($settings['entry_popup']['content']),
             'button_text' => sanitize_text_field($settings['entry_popup']['button_text']),
             'button_color' => sanitize_hex_color($settings['entry_popup']['button_color']),
             'button_url' => esc_url_raw($settings['entry_popup']['button_url']),
@@ -360,6 +366,9 @@ class PopMagique {
             'text_color' => sanitize_hex_color($settings['entry_popup']['text_color']),
             'font_size' => sanitize_text_field($settings['entry_popup']['font_size']),
             'font_family' => sanitize_text_field($settings['entry_popup']['font_family']),
+            'font_weight' => in_array($settings['entry_popup']['font_weight'], array('normal', 'bold'), true) ? $settings['entry_popup']['font_weight'] : 'normal',
+            'font_style' => in_array($settings['entry_popup']['font_style'], array('normal', 'italic'), true) ? $settings['entry_popup']['font_style'] : 'normal',
+            'text_transform' => in_array($settings['entry_popup']['text_transform'], array('none', 'uppercase', 'lowercase', 'capitalize'), true) ? $settings['entry_popup']['text_transform'] : 'none',
             'image_url' => esc_url_raw($settings['entry_popup']['image_url'])
         );
         
@@ -367,11 +376,14 @@ class PopMagique {
         $clean['exit_popup'] = array(
             'enabled' => isset($settings['exit_popup']['enabled']) ? (bool)$settings['exit_popup']['enabled'] : false,
             'title' => sanitize_text_field($settings['exit_popup']['title']),
-            'content' => sanitize_textarea_field($settings['exit_popup']['content']),
+            'content' => wp_kses_post($settings['exit_popup']['content']),
             'background_color' => sanitize_text_field($settings['exit_popup']['background_color']),
             'text_color' => sanitize_hex_color($settings['exit_popup']['text_color']),
             'font_size' => sanitize_text_field($settings['exit_popup']['font_size']),
-            'font_family' => sanitize_text_field($settings['exit_popup']['font_family'])
+            'font_family' => sanitize_text_field($settings['exit_popup']['font_family']),
+            'font_weight' => in_array($settings['exit_popup']['font_weight'], array('normal', 'bold'), true) ? $settings['exit_popup']['font_weight'] : 'normal',
+            'font_style' => in_array($settings['exit_popup']['font_style'], array('normal', 'italic'), true) ? $settings['exit_popup']['font_style'] : 'normal',
+            'text_transform' => in_array($settings['exit_popup']['text_transform'], array('none', 'uppercase', 'lowercase', 'capitalize'), true) ? $settings['exit_popup']['text_transform'] : 'none'
         );
         
         return $clean;

--- a/readme.txt
+++ b/readme.txt
@@ -27,7 +27,7 @@ Système de double popup intelligent avec design glassmorphism pour WordPress. P
 * **Intégration Mailchimp** - Synchronisation automatique avec vos listes
 * **Base de Données Locale** - Stockage des emails directement dans WordPress
 * **Export CSV** - Exportez vos abonnés facilement
-* **Personnalisation Complète** - Couleurs, polices, textes, délais configurables
+* **Personnalisation Complète** - Couleurs, polices (graisse, style, transformation), textes et délais configurables
 
 = Cas d'Usage =
 

--- a/templates/admin-page.php
+++ b/templates/admin-page.php
@@ -133,6 +133,38 @@ if (!defined('ABSPATH')) {
                                 </select>
                             </td>
                         </tr>
+                        <tr>
+                            <th scope="row">Graisse de police</th>
+                            <td>
+                                <select name="entry_popup[font_weight]">
+                                    <option value="normal" <?php selected($options['entry_popup']['font_weight'], 'normal'); ?>>Normal</option>
+                                    <option value="bold" <?php selected($options['entry_popup']['font_weight'], 'bold'); ?>>Gras</option>
+                                </select>
+                                <p class="description">Épaisseur du texte du popup</p>
+                            </td>
+                        </tr>
+                        <tr>
+                            <th scope="row">Style de police</th>
+                            <td>
+                                <select name="entry_popup[font_style]">
+                                    <option value="normal" <?php selected($options['entry_popup']['font_style'], 'normal'); ?>>Normal</option>
+                                    <option value="italic" <?php selected($options['entry_popup']['font_style'], 'italic'); ?>>Italique</option>
+                                </select>
+                                <p class="description">Style du texte du popup</p>
+                            </td>
+                        </tr>
+                        <tr>
+                            <th scope="row">Transformation du texte</th>
+                            <td>
+                                <select name="entry_popup[text_transform]">
+                                    <option value="none" <?php selected($options['entry_popup']['text_transform'], 'none'); ?>>Aucune</option>
+                                    <option value="uppercase" <?php selected($options['entry_popup']['text_transform'], 'uppercase'); ?>>MAJUSCULES</option>
+                                    <option value="lowercase" <?php selected($options['entry_popup']['text_transform'], 'lowercase'); ?>>minuscules</option>
+                                    <option value="capitalize" <?php selected($options['entry_popup']['text_transform'], 'capitalize'); ?>>Capitalize</option>
+                                </select>
+                                <p class="description">Transformation appliquée au texte</p>
+                            </td>
+                        </tr>
                     </table>
                 </div>
             </div>
@@ -208,6 +240,38 @@ if (!defined('ABSPATH')) {
                                     <option value="Georgia, serif" <?php selected($options['exit_popup']['font_family'], 'Georgia, serif'); ?>>Georgia</option>
                                     <option value="'Times New Roman', serif" <?php selected($options['exit_popup']['font_family'], "'Times New Roman', serif"); ?>>Times New Roman</option>
                                 </select>
+                            </td>
+                        </tr>
+                        <tr>
+                            <th scope="row">Graisse de police</th>
+                            <td>
+                                <select name="exit_popup[font_weight]">
+                                    <option value="normal" <?php selected($options['exit_popup']['font_weight'], 'normal'); ?>>Normal</option>
+                                    <option value="bold" <?php selected($options['exit_popup']['font_weight'], 'bold'); ?>>Gras</option>
+                                </select>
+                                <p class="description">Épaisseur du texte du popup</p>
+                            </td>
+                        </tr>
+                        <tr>
+                            <th scope="row">Style de police</th>
+                            <td>
+                                <select name="exit_popup[font_style]">
+                                    <option value="normal" <?php selected($options['exit_popup']['font_style'], 'normal'); ?>>Normal</option>
+                                    <option value="italic" <?php selected($options['exit_popup']['font_style'], 'italic'); ?>>Italique</option>
+                                </select>
+                                <p class="description">Style du texte du popup</p>
+                            </td>
+                        </tr>
+                        <tr>
+                            <th scope="row">Transformation du texte</th>
+                            <td>
+                                <select name="exit_popup[text_transform]">
+                                    <option value="none" <?php selected($options['exit_popup']['text_transform'], 'none'); ?>>Aucune</option>
+                                    <option value="uppercase" <?php selected($options['exit_popup']['text_transform'], 'uppercase'); ?>>MAJUSCULES</option>
+                                    <option value="lowercase" <?php selected($options['exit_popup']['text_transform'], 'lowercase'); ?>>minuscules</option>
+                                    <option value="capitalize" <?php selected($options['exit_popup']['text_transform'], 'capitalize'); ?>>Capitalize</option>
+                                </select>
+                                <p class="description">Transformation appliquée au texte</p>
                             </td>
                         </tr>
                     </table>

--- a/templates/popups.php
+++ b/templates/popups.php
@@ -10,11 +10,14 @@ if (!defined('ABSPATH')) {
     <?php if ($options['entry_popup']['enabled']): ?>
     <div id="popmagique-entry-popup" class="popmagique-popup" style="display: none;">
         <div class="popmagique-backdrop"></div>
-        <div class="popmagique-modal popmagique-entry-modal" 
-             style="background: <?php echo esc_attr($options['entry_popup']['background_color']); ?>; 
+        <div class="popmagique-modal popmagique-entry-modal"
+             style="background: <?php echo esc_attr($options['entry_popup']['background_color']); ?>;
                     color: <?php echo esc_attr($options['entry_popup']['text_color']); ?>;
                     font-family: <?php echo esc_attr($options['entry_popup']['font_family']); ?>;
-                    font-size: <?php echo esc_attr($options['entry_popup']['font_size']); ?>;">
+                    font-size: <?php echo esc_attr($options['entry_popup']['font_size']); ?>;
+                    font-weight: <?php echo esc_attr($options['entry_popup']['font_weight']); ?>;
+                    font-style: <?php echo esc_attr($options['entry_popup']['font_style']); ?>;
+                    text-transform: <?php echo esc_attr($options['entry_popup']['text_transform']); ?>;">
             
             <button class="popmagique-close" type="button">
                 <svg width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2">
@@ -36,7 +39,7 @@ if (!defined('ABSPATH')) {
                 </h2>
                 
                 <p class="popmagique-text">
-                    <?php echo esc_html($options['entry_popup']['content']); ?>
+                    <?php echo wp_kses_post($options['entry_popup']['content']); ?>
                 </p>
                 
                 <div class="popmagique-actions">
@@ -56,11 +59,14 @@ if (!defined('ABSPATH')) {
     <?php if ($options['exit_popup']['enabled']): ?>
     <div id="popmagique-exit-popup" class="popmagique-popup" style="display: none;">
         <div class="popmagique-backdrop"></div>
-        <div class="popmagique-modal popmagique-exit-modal" 
-             style="background: <?php echo esc_attr($options['exit_popup']['background_color']); ?>; 
+        <div class="popmagique-modal popmagique-exit-modal"
+             style="background: <?php echo esc_attr($options['exit_popup']['background_color']); ?>;
                     color: <?php echo esc_attr($options['exit_popup']['text_color']); ?>;
                     font-family: <?php echo esc_attr($options['exit_popup']['font_family']); ?>;
-                    font-size: <?php echo esc_attr($options['exit_popup']['font_size']); ?>;">
+                    font-size: <?php echo esc_attr($options['exit_popup']['font_size']); ?>;
+                    font-weight: <?php echo esc_attr($options['exit_popup']['font_weight']); ?>;
+                    font-style: <?php echo esc_attr($options['exit_popup']['font_style']); ?>;
+                    text-transform: <?php echo esc_attr($options['exit_popup']['text_transform']); ?>;">
             
             <button class="popmagique-close" type="button">
                 <svg width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2">
@@ -75,7 +81,7 @@ if (!defined('ABSPATH')) {
                 </h2>
 
                 <p class="popmagique-text">
-                    <?php echo esc_html($options['exit_popup']['content']); ?>
+                    <?php echo wp_kses_post($options['exit_popup']['content']); ?>
                 </p>
             </div>
         </div>


### PR DESCRIPTION
## Summary
- extend typography settings for entry and exit popups
- allow HTML markup in popup content
- add font weight, style and transform options in admin UI
- output new typography settings in popup templates
- document typography features

## Testing
- `php -l popmagique.php` *(fails: command not found)*
- `php -v` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_685c040f18d8832baff4d56583cbcf3d