### PR TITLE
Update popups design

### DIFF
--- a/popmagique.php
+++ b/popmagique.php
@@ -44,7 +44,21 @@ class PopMagique {
             'delay' => 3000,
             'title' => '🎉 Offre Spéciale !',
             'content' => 'Découvrez nos produits avec 20% de réduction pour les nouveaux visiteurs. Une occasion unique à ne pas manquer !',
-            'button_text' => 'Profiter de l\'offre',
+            'background_color' => 'rgba(255, 255, 255, 0.1)',
+            'text_color' => '#1F2937',
+            'font_size' => '16px',
+            'font_family' => 'Inter, sans-serif',
+            'font_weight' => 'normal',
+            'font_style' => 'normal',
+            'text_transform' => 'none',
+            'text_align' => 'center',
+            'image_url' => ''
+        ),
+        'exit_popup' => array(
+            'enabled' => true,
+            'title' => '✋ Attendez !',
+            'content' => 'Ne partez pas sans profiter de nos meilleures offres.',
+            'button_text' => 'Voir l\'offre',
             'button_color' => '#EC4899',
             'button_url' => '#',
             'background_color' => 'rgba(255, 255, 255, 0.1)',
@@ -54,19 +68,7 @@ class PopMagique {
             'font_weight' => 'normal',
             'font_style' => 'normal',
             'text_transform' => 'none',
-            'image_url' => ''
-        ),
-        'exit_popup' => array(
-            'enabled' => true,
-            'title' => '✋ Attendez !',
-            'content' => 'Ne partez pas sans profiter de nos meilleures offres.',
-            'background_color' => 'rgba(255, 255, 255, 0.1)',
-            'text_color' => '#1F2937',
-            'font_size' => '16px',
-            'font_family' => 'Inter, sans-serif',
-            'font_weight' => 'normal',
-            'font_style' => 'normal',
-            'text_transform' => 'none'
+            'text_align' => 'center'
         )
     );
     
@@ -359,9 +361,6 @@ class PopMagique {
             'delay' => absint($settings['entry_popup']['delay']),
             'title' => sanitize_text_field($settings['entry_popup']['title']),
             'content' => wp_kses_post($settings['entry_popup']['content']),
-            'button_text' => sanitize_text_field($settings['entry_popup']['button_text']),
-            'button_color' => sanitize_hex_color($settings['entry_popup']['button_color']),
-            'button_url' => esc_url_raw($settings['entry_popup']['button_url']),
             'background_color' => sanitize_text_field($settings['entry_popup']['background_color']),
             'text_color' => sanitize_hex_color($settings['entry_popup']['text_color']),
             'font_size' => sanitize_text_field($settings['entry_popup']['font_size']),
@@ -369,6 +368,7 @@ class PopMagique {
             'font_weight' => in_array($settings['entry_popup']['font_weight'], array('normal', 'bold'), true) ? $settings['entry_popup']['font_weight'] : 'normal',
             'font_style' => in_array($settings['entry_popup']['font_style'], array('normal', 'italic'), true) ? $settings['entry_popup']['font_style'] : 'normal',
             'text_transform' => in_array($settings['entry_popup']['text_transform'], array('none', 'uppercase', 'lowercase', 'capitalize'), true) ? $settings['entry_popup']['text_transform'] : 'none',
+            'text_align' => in_array($settings['entry_popup']['text_align'], array('left', 'center', 'right'), true) ? $settings['entry_popup']['text_align'] : 'center',
             'image_url' => esc_url_raw($settings['entry_popup']['image_url'])
         );
         
@@ -377,13 +377,17 @@ class PopMagique {
             'enabled' => isset($settings['exit_popup']['enabled']) ? (bool)$settings['exit_popup']['enabled'] : false,
             'title' => sanitize_text_field($settings['exit_popup']['title']),
             'content' => wp_kses_post($settings['exit_popup']['content']),
+            'button_text' => sanitize_text_field($settings['exit_popup']['button_text']),
+            'button_color' => sanitize_hex_color($settings['exit_popup']['button_color']),
+            'button_url' => esc_url_raw($settings['exit_popup']['button_url']),
             'background_color' => sanitize_text_field($settings['exit_popup']['background_color']),
             'text_color' => sanitize_hex_color($settings['exit_popup']['text_color']),
             'font_size' => sanitize_text_field($settings['exit_popup']['font_size']),
             'font_family' => sanitize_text_field($settings['exit_popup']['font_family']),
             'font_weight' => in_array($settings['exit_popup']['font_weight'], array('normal', 'bold'), true) ? $settings['exit_popup']['font_weight'] : 'normal',
             'font_style' => in_array($settings['exit_popup']['font_style'], array('normal', 'italic'), true) ? $settings['exit_popup']['font_style'] : 'normal',
-            'text_transform' => in_array($settings['exit_popup']['text_transform'], array('none', 'uppercase', 'lowercase', 'capitalize'), true) ? $settings['exit_popup']['text_transform'] : 'none'
+            'text_transform' => in_array($settings['exit_popup']['text_transform'], array('none', 'uppercase', 'lowercase', 'capitalize'), true) ? $settings['exit_popup']['text_transform'] : 'none',
+            'text_align' => in_array($settings['exit_popup']['text_align'], array('left', 'center', 'right'), true) ? $settings['exit_popup']['text_align'] : 'center'
         );
         
         return $clean;

--- a/templates/admin-page.php
+++ b/templates/admin-page.php
@@ -71,25 +71,6 @@ if (!defined('ABSPATH')) {
                                 <p class="description">Image optionnelle à afficher dans le popup</p>
                             </td>
                         </tr>
-                        <tr>
-                            <th scope="row">Texte du bouton</th>
-                            <td>
-                                <input type="text" name="entry_popup[button_text]" value="<?php echo esc_attr($options['entry_popup']['button_text']); ?>" class="regular-text">
-                            </td>
-                        </tr>
-                        <tr>
-                            <th scope="row">URL du bouton</th>
-                            <td>
-                                <input type="url" name="entry_popup[button_url]" value="<?php echo esc_attr($options['entry_popup']['button_url']); ?>" class="regular-text">
-                                <p class="description">URL vers laquelle le bouton redirige</p>
-                            </td>
-                        </tr>
-                        <tr>
-                            <th scope="row">Couleur du bouton</th>
-                            <td>
-                                <input type="color" name="entry_popup[button_color]" value="<?php echo esc_attr($options['entry_popup']['button_color']); ?>">
-                            </td>
-                        </tr>
                     </table>
                 </div>
             </div>
@@ -109,6 +90,16 @@ if (!defined('ABSPATH')) {
                             <th scope="row">Couleur du texte</th>
                             <td>
                                 <input type="color" name="entry_popup[text_color]" value="<?php echo esc_attr($options['entry_popup']['text_color']); ?>">
+                            </td>
+                        </tr>
+                        <tr>
+                            <th scope="row">Alignement du texte</th>
+                            <td>
+                                <select name="entry_popup[text_align]">
+                                    <option value="left" <?php selected($options['entry_popup']['text_align'], 'left'); ?>>Gauche</option>
+                                    <option value="center" <?php selected($options['entry_popup']['text_align'], 'center'); ?>>Centre</option>
+                                    <option value="right" <?php selected($options['entry_popup']['text_align'], 'right'); ?>>Droite</option>
+                                </select>
                             </td>
                         </tr>
                         <tr>
@@ -198,6 +189,25 @@ if (!defined('ABSPATH')) {
                                 <textarea name="exit_popup[content]" rows="4" class="large-text"><?php echo esc_textarea($options['exit_popup']['content']); ?></textarea>
                             </td>
                         </tr>
+                        <tr>
+                            <th scope="row">Texte du bouton</th>
+                            <td>
+                                <input type="text" name="exit_popup[button_text]" value="<?php echo esc_attr($options['exit_popup']['button_text']); ?>" class="regular-text">
+                            </td>
+                        </tr>
+                        <tr>
+                            <th scope="row">URL du bouton</th>
+                            <td>
+                                <input type="url" name="exit_popup[button_url]" value="<?php echo esc_attr($options['exit_popup']['button_url']); ?>" class="regular-text">
+                                <p class="description">URL vers laquelle le bouton redirige</p>
+                            </td>
+                        </tr>
+                        <tr>
+                            <th scope="row">Couleur du bouton</th>
+                            <td>
+                                <input type="color" name="exit_popup[button_color]" value="<?php echo esc_attr($options['exit_popup']['button_color']); ?>">
+                            </td>
+                        </tr>
                     </table>
                 </div>
             </div>
@@ -218,6 +228,16 @@ if (!defined('ABSPATH')) {
                             <th scope="row">Couleur du texte</th>
                             <td>
                                 <input type="color" name="exit_popup[text_color]" value="<?php echo esc_attr($options['exit_popup']['text_color']); ?>">
+                            </td>
+                        </tr>
+                        <tr>
+                            <th scope="row">Alignement du texte</th>
+                            <td>
+                                <select name="exit_popup[text_align]">
+                                    <option value="left" <?php selected($options['exit_popup']['text_align'], 'left'); ?>>Gauche</option>
+                                    <option value="center" <?php selected($options['exit_popup']['text_align'], 'center'); ?>>Centre</option>
+                                    <option value="right" <?php selected($options['exit_popup']['text_align'], 'right'); ?>>Droite</option>
+                                </select>
                             </td>
                         </tr>
                         <tr>

--- a/templates/popups.php
+++ b/templates/popups.php
@@ -17,7 +17,8 @@ if (!defined('ABSPATH')) {
                     font-size: <?php echo esc_attr($options['entry_popup']['font_size']); ?>;
                     font-weight: <?php echo esc_attr($options['entry_popup']['font_weight']); ?>;
                     font-style: <?php echo esc_attr($options['entry_popup']['font_style']); ?>;
-                    text-transform: <?php echo esc_attr($options['entry_popup']['text_transform']); ?>;">
+                    text-transform: <?php echo esc_attr($options['entry_popup']['text_transform']); ?>;
+                    text-align: <?php echo esc_attr($options['entry_popup']['text_align']); ?>;">
             
             <button class="popmagique-close" type="button">
                 <svg width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2">
@@ -42,14 +43,6 @@ if (!defined('ABSPATH')) {
                     <?php echo wp_kses_post($options['entry_popup']['content']); ?>
                 </p>
                 
-                <div class="popmagique-actions">
-                    <a href="<?php echo esc_url($options['entry_popup']['button_url']); ?>" 
-                       class="popmagique-button popmagique-button-primary"
-                       style="background-color: <?php echo esc_attr($options['entry_popup']['button_color']); ?>;"
-                       target="_blank">
-                        <?php echo esc_html($options['entry_popup']['button_text']); ?>
-                    </a>
-                </div>
             </div>
         </div>
     </div>
@@ -66,7 +59,8 @@ if (!defined('ABSPATH')) {
                     font-size: <?php echo esc_attr($options['exit_popup']['font_size']); ?>;
                     font-weight: <?php echo esc_attr($options['exit_popup']['font_weight']); ?>;
                     font-style: <?php echo esc_attr($options['exit_popup']['font_style']); ?>;
-                    text-transform: <?php echo esc_attr($options['exit_popup']['text_transform']); ?>;">
+                    text-transform: <?php echo esc_attr($options['exit_popup']['text_transform']); ?>;
+                    text-align: <?php echo esc_attr($options['exit_popup']['text_align']); ?>;">
             
             <button class="popmagique-close" type="button">
                 <svg width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2">
@@ -83,6 +77,15 @@ if (!defined('ABSPATH')) {
                 <p class="popmagique-text">
                     <?php echo wp_kses_post($options['exit_popup']['content']); ?>
                 </p>
+
+                <div class="popmagique-actions">
+                    <a href="<?php echo esc_url($options['exit_popup']['button_url']); ?>"
+                       class="popmagique-button popmagique-button-primary"
+                       style="background-color: <?php echo esc_attr($options['exit_popup']['button_color']); ?>;"
+                       target="_blank">
+                        <?php echo esc_html($options['exit_popup']['button_text']); ?>
+                    </a>
+                </div>
             </div>
         </div>
     </div>


### PR DESCRIPTION
## Summary
- remove link button from entry popup
- add link button to exit popup
- allow aligning popup text
- expose new exit button settings

## Testing
- `php -l popmagique.php` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_685c07db2c7c832b8a53616d078f68b8