### PR TITLE
Remove popup title fields

### DIFF
--- a/languages/popmagique-fr_FR.po
+++ b/languages/popmagique-fr_FR.po
@@ -67,8 +67,6 @@ msgstr "Délai d'affichage"
 msgid "Délai en millisecondes avant l'affichage (3000 = 3 secondes)"
 msgstr "Délai en millisecondes avant l'affichage (3000 = 3 secondes)"
 
-msgid "Titre"
-msgstr "Titre"
 
 msgid "Contenu"
 msgstr "Contenu"

--- a/popmagique.php
+++ b/popmagique.php
@@ -42,7 +42,6 @@ class PopMagique {
         'entry_popup' => array(
             'enabled' => true,
             'delay' => 3000,
-            'title' => '🎉 Offre Spéciale !',
             'content' => 'Découvrez nos produits avec 20% de réduction pour les nouveaux visiteurs. Une occasion unique à ne pas manquer !',
             'background_color' => 'rgba(255, 255, 255, 0.1)',
             'text_color' => '#1F2937',
@@ -56,7 +55,6 @@ class PopMagique {
         ),
         'exit_popup' => array(
             'enabled' => true,
-            'title' => '✋ Attendez !',
             'content' => 'Ne partez pas sans profiter de nos meilleures offres.',
             'button_text' => 'Voir l\'offre',
             'button_color' => '#EC4899',
@@ -359,7 +357,6 @@ class PopMagique {
         $clean['entry_popup'] = array(
             'enabled' => isset($settings['entry_popup']['enabled']) ? (bool)$settings['entry_popup']['enabled'] : false,
             'delay' => absint($settings['entry_popup']['delay']),
-            'title' => sanitize_text_field($settings['entry_popup']['title']),
             'content' => wp_kses_post($settings['entry_popup']['content']),
             'background_color' => sanitize_text_field($settings['entry_popup']['background_color']),
             'text_color' => sanitize_hex_color($settings['entry_popup']['text_color']),
@@ -375,7 +372,6 @@ class PopMagique {
         // Popup de sortie
         $clean['exit_popup'] = array(
             'enabled' => isset($settings['exit_popup']['enabled']) ? (bool)$settings['exit_popup']['enabled'] : false,
-            'title' => sanitize_text_field($settings['exit_popup']['title']),
             'content' => wp_kses_post($settings['exit_popup']['content']),
             'button_text' => sanitize_text_field($settings['exit_popup']['button_text']),
             'button_color' => sanitize_hex_color($settings['exit_popup']['button_color']),

--- a/templates/admin-page.php
+++ b/templates/admin-page.php
@@ -52,12 +52,6 @@ if (!defined('ABSPATH')) {
                             </td>
                         </tr>
                         <tr>
-                            <th scope="row">Titre</th>
-                            <td>
-                                <input type="text" name="entry_popup[title]" value="<?php echo esc_attr($options['entry_popup']['title']); ?>" class="regular-text">
-                            </td>
-                        </tr>
-                        <tr>
                             <th scope="row">Contenu</th>
                             <td>
                                 <textarea name="entry_popup[content]" rows="4" class="large-text"><?php echo esc_textarea($options['entry_popup']['content']); ?></textarea>
@@ -175,12 +169,6 @@ if (!defined('ABSPATH')) {
                                     <span class="slider"></span>
                                 </label>
                                 <p class="description">Activer ou désactiver le popup de sortie</p>
-                            </td>
-                        </tr>
-                        <tr>
-                            <th scope="row">Titre</th>
-                            <td>
-                                <input type="text" name="exit_popup[title]" value="<?php echo esc_attr($options['exit_popup']['title']); ?>" class="regular-text">
                             </td>
                         </tr>
                         <tr>

--- a/templates/popups.php
+++ b/templates/popups.php
@@ -30,14 +30,9 @@ if (!defined('ABSPATH')) {
             <div class="popmagique-content">
                 <?php if (!empty($options['entry_popup']['image_url'])): ?>
                 <div class="popmagique-image">
-                    <img src="<?php echo esc_url($options['entry_popup']['image_url']); ?>" 
-                         alt="<?php echo esc_attr($options['entry_popup']['title']); ?>">
+                    <img src="<?php echo esc_url($options['entry_popup']['image_url']); ?>" alt="">
                 </div>
                 <?php endif; ?>
-                
-                <h2 class="popmagique-title">
-                    <?php echo esc_html($options['entry_popup']['title']); ?>
-                </h2>
                 
                 <p class="popmagique-text">
                     <?php echo wp_kses_post($options['entry_popup']['content']); ?>
@@ -70,10 +65,6 @@ if (!defined('ABSPATH')) {
             </button>
             
             <div class="popmagique-content">
-                <h2 class="popmagique-title">
-                    <?php echo esc_html($options['exit_popup']['title']); ?>
-                </h2>
-
                 <p class="popmagique-text">
                     <?php echo wp_kses_post($options['exit_popup']['content']); ?>
                 </p>


### PR DESCRIPTION
## Summary
- delete popup title tags from templates
- remove title settings from defaults
- stop sanitizing popup titles
- drop title fields from admin form
- update translation strings

## Testing
- `php -v` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_685c0c0a100c832b81ccdeda3e29ea05