### PR TITLE
Add newsletter subscription form

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,2 +1,10 @@
-# eugene-popup
-popup entrée et sortie
+# PopMagique
+
+PopMagique affiche deux popups pour booster vos conversions :
+
+* **Popup d'Entrée** pour promouvoir vos offres dès l'arrivée du visiteur.
+* **Popup de Sortie** contenant un formulaire d'inscription à la newsletter.
+
+Les emails saisis sont enregistrés dans WordPress via l'action AJAX
+`popmagique_subscribe_email` et consultables depuis la page « Abonnés » de
+l'administration.

--- a/assets/frontend.css
+++ b/assets/frontend.css
@@ -7,3 +7,4 @@
 .popmagique-actions { margin-top: 15px; text-align: center; }
 .popmagique-button { padding: 10px 20px; border: none; cursor: pointer; border-radius: 4px; }
 .popmagique-button-primary { color: #fff; }
+.popmagique-response { margin-top: 10px; text-align: center; }

--- a/assets/frontend.js
+++ b/assets/frontend.js
@@ -25,4 +25,24 @@ jQuery(function($) {
         $(this).closest('.popmagique-popup').fadeOut();
     });
 
+    $('.popmagique-subscribe-form').on('submit', function(e) {
+        e.preventDefault();
+        var form = $(this);
+        var email = form.find('input[name="email"]').val();
+
+        $.post(popmagique_config.ajax_url, {
+            action: 'popmagique_subscribe_email',
+            nonce: popmagique_config.nonce,
+            email: email
+        }, function(response) {
+            var message = form.next('.popmagique-response');
+            if (response.success) {
+                form.hide();
+                message.text(response.data).show();
+            } else {
+                message.text(response.data).show();
+            }
+        });
+    });
+
 });

--- a/readme.txt
+++ b/readme.txt
@@ -26,6 +26,7 @@ Système de double popup intelligent avec design glassmorphism pour WordPress. P
 * **Configuration Intuitive** - Panneau d'administration simple et complet
 * **Intégration Mailchimp** - Synchronisation automatique avec vos listes
 * **Base de Données Locale** - Stockage des emails directement dans WordPress
+* **Formulaire d'inscription** - Le popup de sortie envoie l'email via AJAX
 * **Export CSV** - Exportez vos abonnés facilement
 * **Personnalisation Complète** - Couleurs, polices (graisse, style, transformation), textes et délais configurables
 

--- a/templates/popups.php
+++ b/templates/popups.php
@@ -69,14 +69,15 @@ if (!defined('ABSPATH')) {
                     <?php echo wp_kses_post($options['exit_popup']['content']); ?>
                 </p>
 
-                <div class="popmagique-actions">
-                    <a href="<?php echo esc_url($options['exit_popup']['button_url']); ?>"
-                       class="popmagique-button popmagique-button-primary"
-                       style="background-color: <?php echo esc_attr($options['exit_popup']['button_color']); ?>;"
-                       target="_blank">
+                <form class="popmagique-form popmagique-subscribe-form" action="#">
+                    <input type="email" name="email" placeholder="Votre email" required>
+                    <button type="submit"
+                            class="popmagique-button popmagique-button-primary"
+                            style="background-color: <?php echo esc_attr($options['exit_popup']['button_color']); ?>;">
                         <?php echo esc_html($options['exit_popup']['button_text']); ?>
-                    </a>
-                </div>
+                    </button>
+                </form>
+                <div class="popmagique-response" style="display:none;"></div>
             </div>
         </div>
     </div>


### PR DESCRIPTION
## Summary
- replace exit popup button with a newsletter signup form
- handle form submission via `popmagique_subscribe_email` AJAX action
- style responses in frontend CSS
- document newsletter signup form in README files

## Testing
- `npm test` *(fails: could not find package.json)*

------
https://chatgpt.com/codex/tasks/task_e_685c1f65aa20832b8210fe31417c4c7e