### PR TITLE
Add larger font size options

### DIFF
--- a/languages/popmagique-fr_FR.po
+++ b/languages/popmagique-fr_FR.po
@@ -148,6 +148,24 @@ msgstr "Grande (18px)"
 msgid "Très grande (20px)"
 msgstr "Très grande (20px)"
 
+msgid "22px"
+msgstr "22px"
+
+msgid "24px"
+msgstr "24px"
+
+msgid "26px"
+msgstr "26px"
+
+msgid "28px"
+msgstr "28px"
+
+msgid "30px"
+msgstr "30px"
+
+msgid "32px"
+msgstr "32px"
+
 msgid "Police"
 msgstr "Police"
 

--- a/templates/admin-page.php
+++ b/templates/admin-page.php
@@ -104,6 +104,12 @@ if (!defined('ABSPATH')) {
                                     <option value="16px" <?php selected($options['entry_popup']['font_size'], '16px'); ?>>Normale (16px)</option>
                                     <option value="18px" <?php selected($options['entry_popup']['font_size'], '18px'); ?>>Grande (18px)</option>
                                     <option value="20px" <?php selected($options['entry_popup']['font_size'], '20px'); ?>>Très grande (20px)</option>
+                                    <option value="22px" <?php selected($options['entry_popup']['font_size'], '22px'); ?>>22px</option>
+                                    <option value="24px" <?php selected($options['entry_popup']['font_size'], '24px'); ?>>24px</option>
+                                    <option value="26px" <?php selected($options['entry_popup']['font_size'], '26px'); ?>>26px</option>
+                                    <option value="28px" <?php selected($options['entry_popup']['font_size'], '28px'); ?>>28px</option>
+                                    <option value="30px" <?php selected($options['entry_popup']['font_size'], '30px'); ?>>30px</option>
+                                    <option value="32px" <?php selected($options['entry_popup']['font_size'], '32px'); ?>>32px</option>
                                 </select>
                             </td>
                         </tr>
@@ -236,6 +242,12 @@ if (!defined('ABSPATH')) {
                                     <option value="16px" <?php selected($options['exit_popup']['font_size'], '16px'); ?>>Normale (16px)</option>
                                     <option value="18px" <?php selected($options['exit_popup']['font_size'], '18px'); ?>>Grande (18px)</option>
                                     <option value="20px" <?php selected($options['exit_popup']['font_size'], '20px'); ?>>Très grande (20px)</option>
+                                    <option value="22px" <?php selected($options['exit_popup']['font_size'], '22px'); ?>>22px</option>
+                                    <option value="24px" <?php selected($options['exit_popup']['font_size'], '24px'); ?>>24px</option>
+                                    <option value="26px" <?php selected($options['exit_popup']['font_size'], '26px'); ?>>26px</option>
+                                    <option value="28px" <?php selected($options['exit_popup']['font_size'], '28px'); ?>>28px</option>
+                                    <option value="30px" <?php selected($options['exit_popup']['font_size'], '30px'); ?>>30px</option>
+                                    <option value="32px" <?php selected($options['exit_popup']['font_size'], '32px'); ?>>32px</option>
                                 </select>
                             </td>
                         </tr>


### PR DESCRIPTION
## Summary
- extend font size dropdowns in popup settings up to 32px
- update French translation strings for the new sizes

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_685c21a4ef78832b8dc64e26580e15c2