### PR TITLE
Allow configuring popup width

### DIFF
--- a/popmagique.php
+++ b/popmagique.php
@@ -51,7 +51,8 @@ class PopMagique {
             'font_style' => 'normal',
             'text_transform' => 'none',
             'text_align' => 'center',
-            'image_url' => ''
+            'image_url' => '',
+            'width' => 500
         ),
         'exit_popup' => array(
             'enabled' => true,
@@ -66,7 +67,8 @@ class PopMagique {
             'font_weight' => 'normal',
             'font_style' => 'normal',
             'text_transform' => 'none',
-            'text_align' => 'center'
+            'text_align' => 'center',
+            'width' => 500
         )
     );
     
@@ -367,7 +369,8 @@ class PopMagique {
             'font_style' => in_array($settings['entry_popup']['font_style'], array('normal', 'italic'), true) ? $settings['entry_popup']['font_style'] : 'normal',
             'text_transform' => in_array($settings['entry_popup']['text_transform'], array('none', 'uppercase', 'lowercase', 'capitalize'), true) ? $settings['entry_popup']['text_transform'] : 'none',
             'text_align' => in_array($settings['entry_popup']['text_align'], array('left', 'center', 'right'), true) ? $settings['entry_popup']['text_align'] : 'center',
-            'image_url' => esc_url_raw($settings['entry_popup']['image_url'])
+            'image_url' => esc_url_raw($settings['entry_popup']['image_url']),
+            'width' => absint($settings['entry_popup']['width'])
         );
         
         // Popup de sortie
@@ -384,7 +387,8 @@ class PopMagique {
             'font_weight' => in_array($settings['exit_popup']['font_weight'], array('normal', 'bold'), true) ? $settings['exit_popup']['font_weight'] : 'normal',
             'font_style' => in_array($settings['exit_popup']['font_style'], array('normal', 'italic'), true) ? $settings['exit_popup']['font_style'] : 'normal',
             'text_transform' => in_array($settings['exit_popup']['text_transform'], array('none', 'uppercase', 'lowercase', 'capitalize'), true) ? $settings['exit_popup']['text_transform'] : 'none',
-            'text_align' => in_array($settings['exit_popup']['text_align'], array('left', 'center', 'right'), true) ? $settings['exit_popup']['text_align'] : 'center'
+            'text_align' => in_array($settings['exit_popup']['text_align'], array('left', 'center', 'right'), true) ? $settings['exit_popup']['text_align'] : 'center',
+            'width' => absint($settings['exit_popup']['width'])
         );
         
         return $clean;

--- a/templates/admin-page.php
+++ b/templates/admin-page.php
@@ -156,6 +156,13 @@ if (!defined('ABSPATH')) {
                                 <p class="description">Transformation appliquée au texte</p>
                             </td>
                         </tr>
+                        <tr>
+                            <th scope="row">Largeur max</th>
+                            <td>
+                                <input type="number" name="entry_popup[width]" value="<?php echo esc_attr($options['entry_popup']['width']); ?>" min="200" step="10" class="small-text"> px
+                                <p class="description">Largeur maximale du popup</p>
+                            </td>
+                        </tr>
                     </table>
                 </div>
             </div>
@@ -292,6 +299,13 @@ if (!defined('ABSPATH')) {
                                     <option value="capitalize" <?php selected($options['exit_popup']['text_transform'], 'capitalize'); ?>>Capitalize</option>
                                 </select>
                                 <p class="description">Transformation appliquée au texte</p>
+                            </td>
+                        </tr>
+                        <tr>
+                            <th scope="row">Largeur max</th>
+                            <td>
+                                <input type="number" name="exit_popup[width]" value="<?php echo esc_attr($options['exit_popup']['width']); ?>" min="200" step="10" class="small-text"> px
+                                <p class="description">Largeur maximale du popup</p>
                             </td>
                         </tr>
                     </table>

--- a/templates/popups.php
+++ b/templates/popups.php
@@ -18,7 +18,8 @@ if (!defined('ABSPATH')) {
                     font-weight: <?php echo esc_attr($options['entry_popup']['font_weight']); ?>;
                     font-style: <?php echo esc_attr($options['entry_popup']['font_style']); ?>;
                     text-transform: <?php echo esc_attr($options['entry_popup']['text_transform']); ?>;
-                    text-align: <?php echo esc_attr($options['entry_popup']['text_align']); ?>;">
+                    text-align: <?php echo esc_attr($options['entry_popup']['text_align']); ?>;
+                    max-width: <?php echo isset($options['entry_popup']['width']) ? intval($options['entry_popup']['width']) : 500; ?>px;">
             
             <button class="popmagique-close" type="button">
                 <svg width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2">
@@ -55,7 +56,8 @@ if (!defined('ABSPATH')) {
                     font-weight: <?php echo esc_attr($options['exit_popup']['font_weight']); ?>;
                     font-style: <?php echo esc_attr($options['exit_popup']['font_style']); ?>;
                     text-transform: <?php echo esc_attr($options['exit_popup']['text_transform']); ?>;
-                    text-align: <?php echo esc_attr($options['exit_popup']['text_align']); ?>;">
+                    text-align: <?php echo esc_attr($options['exit_popup']['text_align']); ?>;
+                    max-width: <?php echo isset($options['exit_popup']['width']) ? intval($options['exit_popup']['width']) : 500; ?>px;">
             
             <button class="popmagique-close" type="button">
                 <svg width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2">


### PR DESCRIPTION
## Summary
- add new `width` field for entry and exit popups
- sanitize and output popup width in frontend templates
- expose popup width control in admin settings

## Testing
- `git show --stat`

------
https://chatgpt.com/codex/tasks/task_e_685c24252d34832bb5ae64a2d05e4483