### PR TITLE
Remove email from exit popup

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,8 +3,4 @@
 PopMagique affiche deux popups pour booster vos conversions :
 
 * **Popup d'Entrée** pour promouvoir vos offres dès l'arrivée du visiteur.
-* **Popup de Sortie** contenant un formulaire d'inscription à la newsletter.
-
-Les emails saisis sont enregistrés dans WordPress via l'action AJAX
-`popmagique_subscribe_email` et consultables depuis la page « Abonnés » de
-l'administration.
+* **Popup de Sortie** pour retenir le visiteur avant qu'il ne quitte votre site.

--- a/assets/frontend.css
+++ b/assets/frontend.css
@@ -3,7 +3,6 @@
 .popmagique-backdrop { position: absolute; top: 0; left: 0; width: 100%; height: 100%; background: rgba(0,0,0,0.6); }
 .popmagique-modal { position: relative; padding: 2rem; border-radius: 8px; max-width: 500px; width: 90%; }
 .popmagique-close { position: absolute; top: 10px; right: 10px; background: transparent; border: none; cursor: pointer; }
-.popmagique-form { display: flex; flex-direction: column; gap: 10px; }
 .popmagique-actions { margin-top: 15px; text-align: center; }
 .popmagique-button { padding: 10px 20px; border: none; cursor: pointer; border-radius: 4px; }
 .popmagique-button-primary { color: #fff; }

--- a/assets/frontend.js
+++ b/assets/frontend.js
@@ -25,24 +25,4 @@ jQuery(function($) {
         $(this).closest('.popmagique-popup').fadeOut();
     });
 
-    $('.popmagique-subscribe-form').on('submit', function(e) {
-        e.preventDefault();
-        var form = $(this);
-        var email = form.find('input[name="email"]').val();
-
-        $.post(popmagique_config.ajax_url, {
-            action: 'popmagique_subscribe_email',
-            nonce: popmagique_config.nonce,
-            email: email
-        }, function(response) {
-            var message = form.next('.popmagique-response');
-            if (response.success) {
-                form.hide();
-                message.text(response.data).show();
-            } else {
-                message.text(response.data).show();
-            }
-        });
-    });
-
 });

--- a/popmagique.php
+++ b/popmagique.php
@@ -2,7 +2,7 @@
 /**
  * Plugin Name: PopMagique
  * Plugin URI: https://popmagique.com
- * Description: Système de double popup intelligent avec design glassmorphism pour WordPress. Popup d'entrée publicitaire et popup de sortie newsletter avec détection exit intent.
+ * Description: Système de double popup intelligent avec design glassmorphism pour WordPress. Popup d'entrée publicitaire et popup de sortie promotionnel avec détection exit intent.
  * Version: 1.0.0
  * Author: PopMagique
  * Author URI: https://popmagique.com

--- a/readme.txt
+++ b/readme.txt
@@ -1,6 +1,6 @@
 === PopMagique ===
 Contributors: popmagique
-Tags: popup, newsletter, exit-intent, glassmorphism, conversion
+Tags: popup, exit-intent, glassmorphism, conversion
 Requires at least: 5.0
 Tested up to: 6.4
 Requires PHP: 7.4
@@ -8,14 +8,14 @@ Stable tag: 1.0.0
 License: GPLv2 or later
 License URI: https://www.gnu.org/licenses/gpl-2.0.html
 
-Système de double popup intelligent avec design glassmorphism pour WordPress. Popup d'entrée publicitaire et popup de sortie newsletter avec détection exit intent.
+Système de double popup intelligent avec design glassmorphism pour WordPress. Popup d'entrée publicitaire et popup de sortie promotionnel avec détection exit intent.
 
 == Description ==
 
 **PopMagique** est un plugin WordPress moderne qui vous permet d'augmenter vos conversions grâce à un système de double popup intelligent :
 
 🎯 **Popup d'Entrée** - Affiche automatiquement une publicité ou une offre spéciale après 3 secondes
-✋ **Popup de Sortie** - Détecte l'intention de quitter et propose l'inscription à votre newsletter
+✋ **Popup de Sortie** - Détecte l'intention de quitter et met en avant votre offre
 
 = Fonctionnalités Principales =
 
@@ -24,16 +24,13 @@ Système de double popup intelligent avec design glassmorphism pour WordPress. P
 * **100% Responsive** - Optimisé pour tous les appareils
 * **Interface en Français** - Plugin entièrement traduit
 * **Configuration Intuitive** - Panneau d'administration simple et complet
-* **Intégration Mailchimp** - Synchronisation automatique avec vos listes
-* **Base de Données Locale** - Stockage des emails directement dans WordPress
-* **Formulaire d'inscription** - Le popup de sortie envoie l'email via AJAX
-* **Export CSV** - Exportez vos abonnés facilement
+* **Intégration Mailchimp** - Synchronisation automatique avec vos listes (optionnelle)
 * **Personnalisation Complète** - Couleurs, polices (graisse, style, transformation), textes et délais configurables
 
 = Cas d'Usage =
 
 * **E-commerce** - Promouvoir des offres spéciales et réduire l'abandon de panier
-* **Blogs** - Augmenter les abonnements à la newsletter
+* **Blogs** - Mettre en avant vos contenus avant la sortie du visiteur
 * **Sites Vitrine** - Capturer des leads qualifiés
 * **Landing Pages** - Maximiser les conversions
 
@@ -71,22 +68,14 @@ Absolument ! PopMagique inclut une détection exit intent spécialement conçue 
 
 Oui, vous pouvez modifier les couleurs, polices, tailles, textes et même ajouter vos propres images.
 
-= Les emails sont-ils stockés dans WordPress ? =
-
-Oui, tous les emails sont stockés dans votre base de données WordPress. Vous pouvez aussi les synchroniser avec Mailchimp.
-
-= Le plugin est-il compatible RGPD ? =
-
-Le plugin stocke uniquement les emails fournis volontairement par les utilisateurs. Vous devez ajouter vos propres mentions légales selon vos besoins.
 
 == Screenshots ==
 
 1. Interface d'administration - Configuration du popup d'entrée
 2. Interface d'administration - Configuration du popup de sortie
 3. Popup d'entrée avec design glassmorphism
-4. Popup de sortie avec formulaire newsletter
-5. Liste des abonnés avec statistiques
-6. Aperçu responsive sur mobile
+4. Popup de sortie promotionnel
+5. Aperçu responsive sur mobile
 
 == Changelog ==
 
@@ -96,8 +85,6 @@ Le plugin stocke uniquement les emails fournis volontairement par les utilisateu
 * Popup de sortie avec détection exit intent
 * Design glassmorphism responsive
 * Interface d'administration complète
-* Intégration Mailchimp
-* Export CSV des abonnés
 * Support desktop et mobile
 
 == Upgrade Notice ==

--- a/templates/popups.php
+++ b/templates/popups.php
@@ -71,15 +71,13 @@ if (!defined('ABSPATH')) {
                     <?php echo wp_kses_post($options['exit_popup']['content']); ?>
                 </p>
 
-                <form class="popmagique-form popmagique-subscribe-form" action="#">
-                    <input type="email" name="email" placeholder="Votre email" required>
-                    <button type="submit"
-                            class="popmagique-button popmagique-button-primary"
-                            style="background-color: <?php echo esc_attr($options['exit_popup']['button_color']); ?>;">
+                <div class="popmagique-actions">
+                    <a href="<?php echo esc_url($options['exit_popup']['button_url']); ?>"
+                       class="popmagique-button popmagique-button-primary"
+                       style="background-color: <?php echo esc_attr($options['exit_popup']['button_color']); ?>;">
                         <?php echo esc_html($options['exit_popup']['button_text']); ?>
-                    </button>
-                </form>
-                <div class="popmagique-response" style="display:none;"></div>
+                    </a>
+                </div>
             </div>
         </div>
     </div>


### PR DESCRIPTION
## Summary
- drop email form in exit popup template
- remove related JS handler and styling
- update docs to reflect removal of newsletter signup
- adjust plugin description

## Testing
- `php` not available, so syntax checks could not run

------
https://chatgpt.com/codex/tasks/task_e_685c2713987c832b94faada74c4dc16a