### PR TITLE
Fix missing media enqueue

### DIFF
--- a/popmagique.php
+++ b/popmagique.php
@@ -200,6 +200,8 @@ class PopMagique {
      */
     public function admin_init() {
         wp_enqueue_style('wp-color-picker');
+        // Load WordPress media scripts so the upload button can use the media library
+        wp_enqueue_media();
         wp_enqueue_style('popmagique-admin', POPMAGIQUE_PLUGIN_URL . 'assets/admin.css', array(), POPMAGIQUE_VERSION);
         wp_enqueue_script('popmagique-admin', POPMAGIQUE_PLUGIN_URL . 'assets/admin.js', array('jquery', 'wp-color-picker'), POPMAGIQUE_VERSION, true);
         


### PR DESCRIPTION
## Summary
- allow admin image field to open the WP media modal by enqueuing media scripts

## Testing
- `php -l popmagique.php` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_685c3c75122c832bbcf9eec3bb3d1db2