### PR TITLE
Use TinyMCE editor for popup content

### DIFF
--- a/templates/admin-page.php
+++ b/templates/admin-page.php
@@ -54,7 +54,13 @@ if (!defined('ABSPATH')) {
                         <tr>
                             <th scope="row">Contenu</th>
                             <td>
-                                <textarea name="entry_popup[content]" rows="4" class="large-text"><?php echo esc_textarea($options['entry_popup']['content']); ?></textarea>
+                                <?php
+                                wp_editor(
+                                    wp_kses_post($options['entry_popup']['content']),
+                                    'entry_popup_content',
+                                    array('textarea_name' => 'entry_popup[content]')
+                                );
+                                ?>
                             </td>
                         </tr>
                         <tr>
@@ -187,7 +193,13 @@ if (!defined('ABSPATH')) {
                         <tr>
                             <th scope="row">Contenu</th>
                             <td>
-                                <textarea name="exit_popup[content]" rows="4" class="large-text"><?php echo esc_textarea($options['exit_popup']['content']); ?></textarea>
+                                <?php
+                                wp_editor(
+                                    wp_kses_post($options['exit_popup']['content']),
+                                    'exit_popup_content',
+                                    array('textarea_name' => 'exit_popup[content]')
+                                );
+                                ?>
                             </td>
                         </tr>
                         <tr>


### PR DESCRIPTION
## Summary
- replace textarea inputs with `wp_editor` instances for entry and exit popups

## Testing
- `php -l templates/admin-page.php` *(fails: `php: command not found`)*

------
https://chatgpt.com/codex/tasks/task_e_685c3c77e228832b9109aef8ac950cec